### PR TITLE
Create different database name instead default (otrs)

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -29,7 +29,7 @@ publish:
       - latest
 #      - $${BRANCH}-$${COMMIT:0:8}
 #      - 6.0.6-$${COMMIT:0:8}
-      - 6.0.7
+      - 6.0.8
     file: otrs/Dockerfile
     context: otrs
     environment:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 # docker-otrs Change Log
 
+## 6.0.8 - 2018-06-12
+### Changed
+- Updated to latest OTRS version 6.0.8.
+
 ## 6.0.7 - 2018-05-29
-### Added(
+### Added
 - Check for backup file integrity before starting the restore backup process (OTRS_INSTALL=restore).
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 ### Changed
 - Updated to latest OTRS version 6.0.8.
 
+## 5.0.28 - 2018-06-12
+### Changed
+- Updated to OTRS 5.0.28.
+
 ## 6.0.7 - 2018-05-29
 ### Added
 - Check for backup file integrity before starting the restore backup process (OTRS_INSTALL=restore).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # docker-otrs Change Log
 
+## 6.0.9 - 2018-07-24
+### Changed
+- Updated to latest OTRS version 6.0.9.
+- improvements in custom skins handling.
+### Added
+- New environment variable OTRS_TIMEZONE to set the default timezone.
+
 ## 6.0.8 - 2018-06-12
 ### Changed
 - Updated to latest OTRS version 6.0.8.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,12 @@
 
 ## 5.0.28 - 2018-06-12
 ### Changed
-- Updated to OTRS 5.0.28.
+- Updated otrs-5_0_x branch to OTRS 5.0.28.
+
+## 4.0.30 - 2018-06-12
+### Changed
+- Updated otrs-4_0_x branch to OTRS 4.0.30.
+
 
 ## 6.0.7 - 2018-05-29
 ### Added

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ There are also some other environment variables that can be set to customize the
 * `OTRS_DB_PASSWORD` otrs user database password. If it's not set the password will be randomly generated (recommended).
 * `OTRS_ROOT_PASSWORD` root@localhost user password. Default password is `changeme`.
 * `OTRS_LANGUAGE` Set the default language for both agent and customer interfaces (For example, "es" for spanish).
+* `OTRS_TIMEZONE` to set the default timezone.
 * `OTRS_TICKET_COUNTER` Sets the starting point for the ticket counter.
 * `OTRS_NUMBER_GENERATOR` Sets the ticket number generator, possible values are : *DateChecksum*, *Date*, *AutoIncrement* or *Random*.
 * `SHOW_OTRS_LOGO` To disable the OTRS ASCII logo at container startup.

--- a/README.md
+++ b/README.md
@@ -63,8 +63,9 @@ Those environment variables is what you can configure by running the installer f
 
 The included docker-compose file uses `host mounted data containers` to store the database and configuration contents outside the containers. Please take a look at the `docker-compose.yml` file to see the directory mappings and adjust them to your needs.
 
-### Note ####
-Make sure that the directories on the docker host for both OTRS configuration and the MySQL data containers have the correct permissions to be accessed from within the containers. The `volumes/mysql` directory should be owned by the MySQL user (27) and the `volumes/config` directory must be owned by id 500 and group id 48. Before running `docker-compose up` make sure permissions are ok:
+### Notes ####
+* Any setting set using the previous environment variables cannot be edited later through the web interface, if you need to change them then you need to update it in your docker-compose/env file and restart your container. The reason for this is that OTRS sets as read-only any setting set on `$OTRS_ROOT/Kernel/Config.pm`.
+* Make sure that the directories on the docker host for both OTRS configuration and the MySQL data containers have the correct permissions to be accessed from within the containers. The `volumes/mysql` directory should be owned by the MySQL user (27) and the `volumes/config` directory must be owned by id 500 and group id 48. Before running `docker-compose up` make sure permissions are ok:
 
     chown 27 volumes/mysql
     chown 500:48 volumes/config
@@ -112,7 +113,8 @@ To set the customer interface skin set `OTRS_CUSTOMER_SKIN` environment variable
 
     OTRS_CUSTOMER_SKIN: "ivory"
 
-If you are adding your own skins, the easiest way is create your own `Dockerfile` inherited from this image and then `COPY` the skin files there. You can also set all the environment variables in there too, for example:
+### Custom skin
+If you are adding your own skins, the easiest way is create your own `Dockerfile` inherited from this image and then `COPY` the skin files there. Take a look at the [official documentation](http://doc.otrs.com/doc/manual/developer/stable/en/html/skins.html) on instructions on how to create one. You can also set all the environment variables in there too, for example:
 
     FROM juanluisbaptiste/otrs:latest
     MAINTAINER Foo Bar <foo@bar.com>

--- a/README.md
+++ b/README.md
@@ -107,32 +107,9 @@ To set the agent interface skin set `OTRS_AGENT_SKIN` environment variable, for 
 
     OTRS_AGENT_SKIN: "ivory"
 
-To set the agent Interface logo set `OTRS_AGENT_LOGO`:
-
-    OTRS_AGENT_LOGO: skins/Agent/ivory/img/your_logo.png
-
-You can also control the logo's size and placement (set in px units):
-
-    OTRS_AGENT_LOGO_HEIGHT: 50
-    OTRS_AGENT_LOGO_RIGHT: 40
-    OTRS_AGENT_LOGO_TOP: 5
-    OTRS_AGENT_LOGO_WIDTH: 240
-
 To set the customer interface skin set `OTRS_CUSTOMER_SKIN` environment variable, for example:
 
     OTRS_CUSTOMER_SKIN: "ivory"
-
-To set the customer Interface logo set `OTRS_CUSTOMER_LOGO`:
-
-    OTRS_CUSTOMER_LOGO: skins/Customer/ivory/img/your_logo.png
-
-You can also control the logo's size and placement (set in px units):
-
-    OTRS_CUSTOMER_LOGO_HEIGHT: 50
-    OTRS_CUSTOMER_LOGO_RIGHT: 40
-    OTRS_CUSTOMER_LOGO_TOP: 5
-    OTRS_CUSTOMER_LOGO_WIDTH: 240
-
 
 If you are adding your own skins, the easiest way is create your own `Dockerfile` inherited from this image and then `COPY` the skin files there. You can also set all the environment variables in there too, for example:
 

--- a/README.md
+++ b/README.md
@@ -50,8 +50,9 @@ There are also some other environment variables that can be set to customize the
 * `OTRS_DB_HOST` Hostname or IP address of the database server. Default is `mariadb`.
 * `OTRS_DB_PORT` Port of the database server. Default is `3306`.
 * `OTRS_DB_USER` Database user. Default is `otrs`.
-* `OTRS_DB_PASSWORD` otrs user database password. If it's not set the password will be randomly generated (recommended).
+* `OTRS_DB_PASSWORD` otrs user database password. Default password is `changeme`.
 * `OTRS_ROOT_PASSWORD` root@localhost user password. Default password is `changeme`.
+* `MYSQL_ROOT_PASSWORD` Database root password so it can be setup. Default password is `changeme`.
 * `OTRS_LANGUAGE` Set the default language for both agent and customer interfaces (For example, "es" for spanish).
 * `OTRS_TIMEZONE` to set the default timezone.
 * `OTRS_TICKET_COUNTER` Sets the starting point for the ticket counter.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
     env_file: otrs-setup.env
     volumes:
       - './volumes/config:/opt/otrs/Kernel'
+      - ./volumes/skins:/opt/otrs/var/httpd/htdocs/skins/
       - './volumes/backup:/var/otrs/backups'
       - '/etc/localtime:/etc/localtime:ro'
   mariadb:

--- a/launch-testing.sh
+++ b/launch-testing.sh
@@ -6,6 +6,7 @@ BUILD_IMAGE=0
 BUILD_NOCACHE=""
 CLEAN=0
 DEBUG=0
+RUN=0
 params=""
 
 usage()
@@ -20,6 +21,7 @@ OPTIONS:
 -b    Build image.
 -B    Build image (--no-cache).
 -c    Clean volumes.
+-r    Run container.
 -h    Print help.
 -V    Debug mode.
 
@@ -33,7 +35,7 @@ function ctrl_c() {
         exit 0
 }
 
-while getopts bBchV option
+while getopts bBcrhV option
 do
   case "${option}"
   in
@@ -42,6 +44,8 @@ do
     B) BUILD_NOCACHE="--no-cache"
        ;;
     c) CLEAN=1
+       ;;
+    r) RUN=1
        ;;
     h) usage
        exit
@@ -76,4 +80,4 @@ if [ ${BUILD_IMAGE} -eq 1 ]; then
     paplay /usr/share/sounds/freedesktop/stereo/complete.oga
   fi
 fi
-docker-compose up
+[ ${RUN} -eq 1  ] && docker-compose up

--- a/launch-testing.sh
+++ b/launch-testing.sh
@@ -41,7 +41,8 @@ do
   in
     b) BUILD_IMAGE=1
        ;;
-    B) BUILD_NOCACHE="--no-cache"
+    B) BUILD_IMAGE=1
+       BUILD_NOCACHE="--no-cache"
        ;;
     c) CLEAN=1
        ;;

--- a/otrs/Dockerfile
+++ b/otrs/Dockerfile
@@ -1,7 +1,7 @@
 #OTRS ticketing system docker image.
 FROM centos:7
 MAINTAINER Juan Luis Baptiste <juan.baptiste@gmail.com>
-ENV OTRS_VERSION=6.0.8-01
+ENV OTRS_VERSION=6.0.9-01
 ENV OTRS_ROOT "/opt/otrs/"
 ENV OTRS_BACKUP_DIR "/var/otrs/backups"
 ENV OTRS_CONFIG_DIR "${OTRS_ROOT}Kernel"

--- a/otrs/Dockerfile
+++ b/otrs/Dockerfile
@@ -6,6 +6,7 @@ ENV OTRS_ROOT "/opt/otrs/"
 ENV OTRS_BACKUP_DIR "/var/otrs/backups"
 ENV OTRS_CONFIG_DIR "${OTRS_ROOT}Kernel"
 ENV OTRS_CONFIG_MOUNT_DIR "/config/"
+ENV OTRS_SKINS_MOUNT_DIR "/skins/"
 ENV SKINS_PATH "${OTRS_ROOT}/var/httpd/htdocs/skins/"
 
 RUN yum install -y yum-plugin-fastestmirror && \
@@ -48,8 +49,9 @@ RUN chmod 755 /*.sh  && \
 #To be able to use a host-mounted volume for OTRS configuration we need to move
 #away the contents of ${OTRS_CONFIG_DIR} to another place and move them back
 #on first container run (see check_host_mount_dir on functions.sh), after the
-#host-volume is mounted.
+#host-volume is mounted. The same for the skins.
 RUN mv ${OTRS_CONFIG_DIR} / && \
+    mv ${SKINS_PATH} / && \
     touch ${OTRS_ROOT}var/tmp/firsttime
 EXPOSE 80
 CMD ["/run.sh"]

--- a/otrs/Dockerfile
+++ b/otrs/Dockerfile
@@ -1,7 +1,7 @@
 #OTRS ticketing system docker image.
 FROM centos:7
 MAINTAINER Juan Luis Baptiste <juan.baptiste@gmail.com>
-ENV OTRS_VERSION=6.0.7-01
+ENV OTRS_VERSION=6.0.8-01
 ENV OTRS_ROOT "/opt/otrs/"
 ENV OTRS_BACKUP_DIR "/var/otrs/backups"
 ENV OTRS_CONFIG_DIR "${OTRS_ROOT}Kernel"

--- a/otrs/functions.sh
+++ b/otrs/functions.sh
@@ -226,7 +226,12 @@ function set_ticket_counter() {
 }
 
 function set_skins() {
-  [ ! -z ${OTRS_AGENT_SKIN} ] &&  add_config_value "Loader::Agent::DefaultSelectedSkin" ${OTRS_AGENT_SKIN}
+  if [ ! -z ${OTRS_AGENT_SKIN} ]; then
+    print_info "Setting custom logo..."
+    add_config_value "Loader::Agent::DefaultSelectedSkin" ${OTRS_AGENT_SKIN}
+    # Remove AgentLogo option to disable default logo so the skin one is picked up
+    sed -i '/AgentLogo/,/;/d' ${OTRS_CONFIG_DIR}/Config/Files/ZZZAAuto.pm
+  fi
   [ ! -z ${OTRS_AGENT_SKIN} ] &&  add_config_value "Loader::Customer::SelectedSkin" ${OTRS_CUSTOMER_SKIN}
 }
 

--- a/otrs/functions.sh
+++ b/otrs/functions.sh
@@ -231,6 +231,8 @@ function set_skins() {
     add_config_value "Loader::Agent::DefaultSelectedSkin" ${OTRS_AGENT_SKIN}
     # Remove AgentLogo option to disable default logo so the skin one is picked up
     sed -i '/AgentLogo/,/;/d' ${OTRS_CONFIG_DIR}/Config/Files/ZZZAAuto.pm
+    # Also disable default value of sysconfig so XML/Framework.xml AgentLogo is valid=0 
+    $mysqlcmd -e "UPDATE sysconfig_default SET is_valid = 0 WHERE name = 'AgentLogo'" otrs
   fi
   [ ! -z ${OTRS_AGENT_SKIN} ] &&  add_config_value "Loader::Customer::SelectedSkin" ${OTRS_CUSTOMER_SKIN}
 }

--- a/otrs/functions.sh
+++ b/otrs/functions.sh
@@ -177,6 +177,7 @@ function setup_otrs_config() {
   add_config_value "DatabaseHost" ${OTRS_DB_HOST}
   #Set general configuration values
   [ ! -z "${OTRS_LANGUAGE}" ] && add_config_value "DefaultLanguage" ${OTRS_LANGUAGE}
+  [ ! -z "${OTRS_TIMEZONE}" ] && add_config_value "OTRSTimeZone" ${OTRS_TIMEZONE} && add_config_value "UserDefaultTimeZone" ${OTRS_TIMEZONE}
   add_config_value "FQDN" ${OTRS_HOSTNAME}
   #Set email SMTP configuration
   add_config_value "SendmailModule" "Kernel::System::Email::SMTP"

--- a/otrs/functions.sh
+++ b/otrs/functions.sh
@@ -189,6 +189,7 @@ function load_defaults() {
   #Check if a host-mounted volume for configuration storage was added to this
   #container
   check_host_mount_dir
+  check_custom_skins_dir
   #Setup OTRS configuration
   setup_otrs_config
 
@@ -251,6 +252,20 @@ function check_host_mount_dir() {
     fi
   else
     print_info "Found existing configuration directory, Ok."
+  fi
+}
+
+function check_custom_skins_dir() {
+  #Copy the default skins from /skins (put there by the Dockerfile) to $SKINS_PATH
+  #to be able to use host-mounted volumes.
+  print_info "Copying default skins..."
+  mkdir -p ${SKINS_PATH}
+  cp -rfp ${OTRS_SKINS_MOUNT_DIR}/* ${SKINS_PATH}
+  if [ $? -eq 0 ];
+    then
+      print_info "Done."
+    else
+      print_error "Can't copy default skins to ${SKINS_PATH}" && exit 1
   fi
 }
 

--- a/otrs/functions.sh
+++ b/otrs/functions.sh
@@ -228,8 +228,8 @@ function set_ticket_counter() {
 
 function set_skins() {
   if [ ! -z ${OTRS_AGENT_SKIN} ]; then
-    print_info "Setting custom logo..."
     add_config_value "Loader::Agent::DefaultSelectedSkin" ${OTRS_AGENT_SKIN}
+    print_info "Setting Agent interface custom logo..."
     # Remove AgentLogo option to disable default logo so the skin one is picked up
     sed -i '/AgentLogo/,/;/d' ${OTRS_CONFIG_DIR}/Config/Files/ZZZAAuto.pm
     # Also disable default value of sysconfig so XML/Framework.xml AgentLogo is valid=0 

--- a/otrs/functions.sh
+++ b/otrs/functions.sh
@@ -176,7 +176,7 @@ function setup_otrs_config() {
   add_config_value "DatabasePw" ${OTRS_DB_PASSWORD}
   add_config_value "DatabaseHost" ${OTRS_DB_HOST}
   #Set general configuration values
-  add_config_value "DefaultLanguage" ${OTRS_LANGUAGE}
+  [ ! -z "${OTRS_LANGUAGE}" ] && add_config_value "DefaultLanguage" ${OTRS_LANGUAGE}
   add_config_value "FQDN" ${OTRS_HOSTNAME}
   #Set email SMTP configuration
   add_config_value "SendmailModule" "Kernel::System::Email::SMTP"

--- a/otrs/otrs_backup.sh
+++ b/otrs/otrs_backup.sh
@@ -11,7 +11,7 @@ DEFAULT_BACKUP_TYPE="fullbackup"
 trap cleanup INT
 
 function get_current_date(){
-   date "+%d-%m-%Y_%H_%M"
+   date "+%Y-%m-%d_%H_%M"
 }
 
 # SIGTERM-handler

--- a/otrs/run.sh
+++ b/otrs/run.sh
@@ -48,7 +48,6 @@ if [ "${OTRS_INSTALL}" != "yes" ]; then
     restore_backup ${OTRS_BACKUP_DATE}
   fi
   reinstall_modules
-  set_skins
   set_ticket_counter
   rm -fr ${OTRS_ROOT}var/tmp/firsttime
   #Start OTRS
@@ -57,6 +56,7 @@ if [ "${OTRS_INSTALL}" != "yes" ]; then
   su -c "${OTRS_ROOT}bin/otrs.Daemon.pl start" -s /bin/bash otrs
   su -c "${OTRS_ROOT}bin/otrs.Console.pl Maint::Config::Rebuild" -s /bin/bash otrs
   su -c "${OTRS_ROOT}bin/otrs.Console.pl Maint::Cache::Delete" -s /bin/bash otrs
+  set_skins
 else
   #If neither of previous cases is true the installer will be run.
   print_info "Starting \e[${OTRS_ASCII_COLOR_BLUE}m OTRS $OTRS_VERSION \e[0minstaller !!"


### PR DESCRIPTION
I was having trouble when creating database giving it a different name (otrs1 instead otrs). To create a different database name I needed to add thin line in otrs/function.sh:

(below line nº 177)
add_config_value "Database" ${OTRS_DB_NAME}

I had this trouble in my project because I needed to create multiple OTRS containers and create different databases for each otrs service.