### PR TITLE
make SendmailModule configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -89,17 +89,20 @@ OTRS_BACKUP_TYPE="fullbackup"
 # SMTP Relay Configuration
 #####################################
 
+# Keep SMTP-Settings configurable via SysConf (Optional, Default value: disabled, Allowd values: enabled/disabled)
+# CONFIGURE_MAIL_VIA_SYSCONF="disabled"
+
+# Module OTRS should use to send mails (e.g "SMTP", "SMTPS", "Sendmail"). Depends on the modules you've installed
+#SENDMAIL_MODULE="SMTP"
+
 # Server address of the SMTP server to use.
-SMTP_SERVER=
+# SMTP_SERVER=
 
 # Port address of the SMTP server to use. (Optional, Default value: 587)
-#SMTP_PORT=587
+# SMTP_PORT=
 
 # Username to authenticate with.
-SMTP_USERNAME=
+# SMTP_USERNAME=
 
 # Password of the SMTP user.
-SMTP_PASSWORD=
-
-# Server hostname for the Postfix container. Emails will appear to come from the hostname's domain.
-SERVER_HOSTNAME=
+# SMTP_PASSWORD=

--- a/.env.example
+++ b/.env.example
@@ -92,16 +92,13 @@ OTRS_BACKUP_TYPE="fullbackup"
 # SMTP Relay Configuration
 #####################################
 
-# Keep SMTP-Settings configurable via SysConf (Optional, Default value: disabled, Allowd values: enabled/disabled)
-# CONFIGURE_MAIL_VIA_SYSCONF="disabled"
-
 # Module OTRS should use to send mails (e.g "SMTP", "SMTPS", "Sendmail"). Depends on the modules you've installed
 #SENDMAIL_MODULE="SMTP"
 
 # Server address of the SMTP server to use.
 # SMTP_SERVER=
 
-# Port address of the SMTP server to use. (Optional, Default value: 587)
+# Port address of the SMTP server to use.
 # SMTP_PORT=
 
 # Username to authenticate with.

--- a/README.md
+++ b/README.md
@@ -60,12 +60,11 @@ There are also some other environment variables that can be set to customize the
 * `OTRS_TICKET_COUNTER` Sets the starting point for the ticket counter.
 * `OTRS_NUMBER_GENERATOR` Sets the ticket number generator, possible values are : *DateChecksum*, *Date*, *AutoIncrement* or *Random*.
 * `SHOW_OTRS_LOGO` To disable the OTRS ASCII logo at container startup.
-* `CONFIGURE_MAIL_VIA_SYSCONF` Defines if the smtp-settings (set via `.env` file) should be applied or if you want to be able to change them aftewards via SysConf. Default is `disabled`
-* `SENDMAIL_MODULE` Module OTRS should use to send mails (e.g `SMTP`, `SMTPS`, `Sendmail`). Depends on the modules you've installed. Won't be applied if `CONFIGURE_MAIL_VIA_SYSCONF` is set to `enabled`. Default is `SMTP`
-* `SMTP_SERVER` Server address of the SMTP server to use. Won't be applied if `CONFIGURE_MAIL_VIA_SYSCONF` is set to `enabled`. Default is `postfix`
-* `SMTP_PORT` Port of the SMTP server to use. Won't be applied if `CONFIGURE_MAIL_VIA_SYSCONF` is set to `enabled`. Default is `25`
-* `SMTP_USERNAME` Username to authenticate with. Won't be applied if `CONFIGURE_MAIL_VIA_SYSCONF` is set to `enabled`. (Optional, unset by default)
-* `SMTP_PASSWORD` Password to authenticate with. Won't be applied if `CONFIGURE_MAIL_VIA_SYSCONF` is set to `enabled`. (Optional, unset by default)
+* `SENDMAIL_MODULE` Module OTRS should use to send mails (e.g `SMTP`, `SMTPS`, `Sendmail`).
+* `SMTP_SERVER` Server address of the SMTP server to use.
+* `SMTP_PORT` Port of the SMTP server to use.
+* `SMTP_USERNAME` Username to authenticate with.
+* `SMTP_PASSWORD` Password to authenticate with.
 
 Those environment variables is what you can configure by running the installer for a default install, plus other useful ones.
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ There are also some other environment variables that can be set to customize the
 * `OTRS_TICKET_COUNTER` Sets the starting point for the ticket counter.
 * `OTRS_NUMBER_GENERATOR` Sets the ticket number generator, possible values are : *DateChecksum*, *Date*, *AutoIncrement* or *Random*.
 * `SHOW_OTRS_LOGO` To disable the OTRS ASCII logo at container startup.
+* `CONFIGURE_MAIL_VIA_SYSCONF` Defines if the smtp-settings (set via `.env` file) should be applied or if you want to be able to change them aftewards via SysConf. Default is `disabled`
+* `SENDMAIL_MODULE` Module OTRS should use to send mails (e.g `SMTP`, `SMTPS`, `Sendmail`). Depends on the modules you've installed. Won't be applied if `CONFIGURE_MAIL_VIA_SYSCONF` is set to `enabled`. Default is `SMTP`
+* `SMTP_SERVER` Server address of the SMTP server to use. Won't be applied if `CONFIGURE_MAIL_VIA_SYSCONF` is set to `enabled`. Default is `postfix`
+* `SMTP_PORT` Port of the SMTP server to use. Won't be applied if `CONFIGURE_MAIL_VIA_SYSCONF` is set to `enabled`. Default is `25`
+* `SMTP_USERNAME` Username to authenticate with. Won't be applied if `CONFIGURE_MAIL_VIA_SYSCONF` is set to `enabled`. (Optional, unset by default)
+* `SMTP_PASSWORD` Password to authenticate with. Won't be applied if `CONFIGURE_MAIL_VIA_SYSCONF` is set to `enabled`. (Optional, unset by default)
 
 Those environment variables is what you can configure by running the installer for a default install, plus other useful ones.
 

--- a/otrs/functions.sh
+++ b/otrs/functions.sh
@@ -47,6 +47,10 @@ DEFAULT_MYSQL_ROOT_USER="root"
 DEFAULT_OTRS_DB_HOST="mariadb"
 DEFAULT_OTRS_DB_PORT=3306
 DEFAULT_OTRS_BACKUP_TIME="0 4 * * *"
+DEFAULT_SMTP_SERVER="postfix"
+DEFAULT_SMTP_PORT=25
+DEFAULT_SENDMAIL_MODULE="SMTP"
+DEFAULT_CONFIGURE_MAIL_VIA_SYSCONF="disabled"
 OTRS_BACKUP_DIR="/var/otrs/backups"
 OTRS_CONFIG_DIR="${OTRS_ROOT}Kernel/"
 OTRS_CONFIG_FILE="${OTRS_CONFIG_DIR}Config.pm"
@@ -68,6 +72,10 @@ OTRS_BACKUP_SCRIPT="/otrs_backup.sh"
 [ -z "${MYSQL_ROOT_PASSWORD}" ] && print_info "\e[${OTRS_ASCII_COLOR_BLUE}mMYSQL_ROOT_PASSWORD\e[0m not set, setting password to \e[${OTRS_ASCII_COLOR_RED}m${DEFAULT_MYSQL_ROOT_PASSWORD}\e[0m" && MYSQL_ROOT_PASSWORD=${DEFAULT_MYSQL_ROOT_PASSWORD}
 [ -z "${MYSQL_ROOT_USER}" ] && print_info "\e[${OTRS_ASCII_COLOR_BLUE}mMYSQL_ROOT_USER\e[0m not set, setting user to \e[${OTRS_ASCII_COLOR_RED}m${DEFAULT_MYSQL_ROOT_USER}\e[0m" && MYSQL_ROOT_USER=${DEFAULT_MYSQL_ROOT_USER}
 [ -z "${OTRS_BACKUP_TIME}" ] && print_info "\e[${OTRS_ASCII_COLOR_BLUE}mOTRS_BACKUP_TIME\e[0m not set, setting value to \e[${OTRS_ASCII_COLOR_RED}m${DEFAULT_OTRS_BACKUP_TIME}\e[0m" && OTRS_BACKUP_TIME=${DEFAULT_OTRS_BACKUP_TIME}
+[ -z "${SMTP_SERVER}" ] && print_info "\e[${OTRS_ASCII_COLOR_BLUE}mSMTP_SERVER\e[0m not set, setting value to \e[${OTRS_ASCII_COLOR_RED}m${DEFAULT_SMTP_SERVER}\e[0m" && SMTP_SERVER=${DEFAULT_SMTP_SERVER}
+[ -z "${SMTP_PORT}" ] && print_info "\e[${OTRS_ASCII_COLOR_BLUE}mSMTP_PORT\e[0m not set, setting value to \e[${OTRS_ASCII_COLOR_RED}m${DEFAULT_SMTP_PORT}\e[0m" && SMTP_PORT=${DEFAULT_SMTP_PORT}
+[ -z "${SENDMAIL_MODULE}" ] && print_info "\e[${OTRS_ASCII_COLOR_BLUE}mSENDMAIL_MODULE\e[0m not set, setting value to \e[${OTRS_ASCII_COLOR_RED}m${DEFAULT_SENDMAIL_MODULE}\e[0m" && SENDMAIL_MODULE=${DEFAULT_SENDMAIL_MODULE}
+[ -z "${CONFIGURE_MAIL_VIA_SYSCONF}" ] && print_info "\e[${OTRS_ASCII_COLOR_BLUE}mCONFIGURE_MAIL_VIA_SYSCONF\e[0m not set, setting value to \e[${OTRS_ASCII_COLOR_RED}m${DEFAULT_CONFIGURE_MAIL_VIA_SYSCONF}\e[0m" && CONFIGURE_MAIL_VIA_SYSCONF=${DEFAULT_CONFIGURE_MAIL_VIA_SYSCONF}
 
 mysqlcmd="mysql -u${MYSQL_ROOT_USER} -h ${OTRS_DB_HOST} -P ${OTRS_DB_PORT} -p${MYSQL_ROOT_PASSWORD} "
 
@@ -203,9 +211,14 @@ function setup_otrs_config() {
   [ ! -z "${OTRS_TIMEZONE}" ] && add_config_value "OTRSTimeZone" ${OTRS_TIMEZONE} && add_config_value "UserDefaultTimeZone" ${OTRS_TIMEZONE}
   add_config_value "FQDN" ${OTRS_HOSTNAME}
   #Set email SMTP configuration
-  add_config_value "SendmailModule" "Kernel::System::Email::SMTP"
-  add_config_value "SendmailModule::Host" "postfix"
-  add_config_value "SendmailModule::Port" "25"
+
+  if [ ${CONFIGURE_MAIL_VIA_SYSCONF} != 'enabled' ]; then
+    add_config_value "SendmailModule" "Kernel::System::Email::${SENDMAIL_MODULE}"
+    add_config_value "SendmailModule::Host" "${SMTP_SERVER}"
+    add_config_value "SendmailModule::Port" "${SMTP_PORT}"
+    [ ! -z "${SMTP_USERNAME}" ] && add_config_value "SendmailModule::AuthUser" "${SMTP_USERNAME}"
+    [ ! -z "${SMTP_PASSWORD}" ] && add_config_value "SendmailModule::AuthPassword" "${SMTP_PASSWORD}"
+  fi
   add_config_value "SecureMode" "1"
   # Configure automatic backups
   setup_backup_cron

--- a/otrs/functions.sh
+++ b/otrs/functions.sh
@@ -56,10 +56,6 @@ DEFAULT_MYSQL_ROOT_USER="root"
 DEFAULT_OTRS_DB_HOST="mariadb"
 DEFAULT_OTRS_DB_PORT=3306
 DEFAULT_OTRS_BACKUP_TIME="0 4 * * *"
-DEFAULT_SMTP_SERVER="postfix"
-DEFAULT_SMTP_PORT=25
-DEFAULT_SENDMAIL_MODULE="SMTP"
-DEFAULT_CONFIGURE_MAIL_VIA_SYSCONF="disabled"
 OTRS_BACKUP_DIR="/var/otrs/backups"
 OTRS_CONFIG_DIR="${OTRS_ROOT}Kernel/"
 OTRS_CONFIG_FILE="${OTRS_CONFIG_DIR}Config.pm"
@@ -82,10 +78,6 @@ OTRS_BACKUP_SCRIPT="/otrs_backup.sh"
 [ -z "${MYSQL_ROOT_PASSWORD}" ] && print_info "\e[${OTRS_ASCII_COLOR_BLUE}mMYSQL_ROOT_PASSWORD\e[0m not set, setting password to \e[${OTRS_ASCII_COLOR_RED}m${DEFAULT_MYSQL_ROOT_PASSWORD}\e[0m" && MYSQL_ROOT_PASSWORD=${DEFAULT_MYSQL_ROOT_PASSWORD}
 [ -z "${MYSQL_ROOT_USER}" ] && print_info "\e[${OTRS_ASCII_COLOR_BLUE}mMYSQL_ROOT_USER\e[0m not set, setting user to \e[${OTRS_ASCII_COLOR_RED}m${DEFAULT_MYSQL_ROOT_USER}\e[0m" && MYSQL_ROOT_USER=${DEFAULT_MYSQL_ROOT_USER}
 [ -z "${OTRS_BACKUP_TIME}" ] && print_info "\e[${OTRS_ASCII_COLOR_BLUE}mOTRS_BACKUP_TIME\e[0m not set, setting value to \e[${OTRS_ASCII_COLOR_RED}m${DEFAULT_OTRS_BACKUP_TIME}\e[0m" && OTRS_BACKUP_TIME=${DEFAULT_OTRS_BACKUP_TIME}
-[ -z "${SMTP_SERVER}" ] && print_info "\e[${OTRS_ASCII_COLOR_BLUE}mSMTP_SERVER\e[0m not set, setting value to \e[${OTRS_ASCII_COLOR_RED}m${DEFAULT_SMTP_SERVER}\e[0m" && SMTP_SERVER=${DEFAULT_SMTP_SERVER}
-[ -z "${SMTP_PORT}" ] && print_info "\e[${OTRS_ASCII_COLOR_BLUE}mSMTP_PORT\e[0m not set, setting value to \e[${OTRS_ASCII_COLOR_RED}m${DEFAULT_SMTP_PORT}\e[0m" && SMTP_PORT=${DEFAULT_SMTP_PORT}
-[ -z "${SENDMAIL_MODULE}" ] && print_info "\e[${OTRS_ASCII_COLOR_BLUE}mSENDMAIL_MODULE\e[0m not set, setting value to \e[${OTRS_ASCII_COLOR_RED}m${DEFAULT_SENDMAIL_MODULE}\e[0m" && SENDMAIL_MODULE=${DEFAULT_SENDMAIL_MODULE}
-[ -z "${CONFIGURE_MAIL_VIA_SYSCONF}" ] && print_info "\e[${OTRS_ASCII_COLOR_BLUE}mCONFIGURE_MAIL_VIA_SYSCONF\e[0m not set, setting value to \e[${OTRS_ASCII_COLOR_RED}m${DEFAULT_CONFIGURE_MAIL_VIA_SYSCONF}\e[0m" && CONFIGURE_MAIL_VIA_SYSCONF=${DEFAULT_CONFIGURE_MAIL_VIA_SYSCONF}
 
 mysqlcmd="mysql -u${MYSQL_ROOT_USER} -h ${OTRS_DB_HOST} -P ${OTRS_DB_PORT} -p${MYSQL_ROOT_PASSWORD} "
 
@@ -222,13 +214,11 @@ function setup_otrs_config() {
   add_config_value "FQDN" ${OTRS_HOSTNAME}
   #Set email SMTP configuration
 
-  if [ ${CONFIGURE_MAIL_VIA_SYSCONF} != 'enabled' ]; then
-    add_config_value "SendmailModule" "Kernel::System::Email::${SENDMAIL_MODULE}"
-    add_config_value "SendmailModule::Host" "${SMTP_SERVER}"
-    add_config_value "SendmailModule::Port" "${SMTP_PORT}"
-    [ ! -z "${SMTP_USERNAME}" ] && add_config_value "SendmailModule::AuthUser" "${SMTP_USERNAME}"
-    [ ! -z "${SMTP_PASSWORD}" ] && add_config_value "SendmailModule::AuthPassword" "${SMTP_PASSWORD}"
-  fi
+  [ ! -z "${SENDMAIL_MODULE}" ] && add_config_value "SendmailModule" "Kernel::System::Email::${SENDMAIL_MODULE}"
+  [ ! -z "${SMTP_SERVER}" ] && add_config_value "SendmailModule::Host" "${SMTP_SERVER}"
+  [ ! -z "${SMTP_PORT}" ] && add_config_value "SendmailModule::Port" "${SMTP_PORT}"
+  [ ! -z "${SMTP_USERNAME}" ] && add_config_value "SendmailModule::AuthUser" "${SMTP_USERNAME}"
+  [ ! -z "${SMTP_PASSWORD}" ] && add_config_value "SendmailModule::AuthPassword" "${SMTP_PASSWORD}"
   add_config_value "SecureMode" "1"
   # Configure automatic backups
   setup_backup_cron


### PR DESCRIPTION
fixes #34 

I've added a switch to completely disable writing the smtp-settings to the Config.pm which allows us to configure those settings via SysConf.

P.S.
Oh, btw. Feel free to edit anything you like if there are any mistakes (i.e. spelling, prefered syntax).