### PR TITLE
fix docker secret support

### DIFF
--- a/otrs/functions.sh
+++ b/otrs/functions.sh
@@ -65,7 +65,7 @@ OTRS_ASCII_COLOR_BLUE="38;5;31"
 OTRS_ASCII_COLOR_RED="31"
 OTRS_BACKUP_SCRIPT="/otrs_backup.sh"
 
-[ ! -z "${OTRS_SECRETS_FILE}"] && apply_docker_secrets
+[ ! -z "${OTRS_SECRETS_FILE}" ] && apply_docker_secrets
 [ -z "${OTRS_INSTALL}" ] && OTRS_INSTALL="no"
 [ -z "${OTRS_DB_NAME}" ] && print_info "\e[${OTRS_ASCII_COLOR_BLUE}mOTRS_DB_NAME\e[0m not set, setting value to \e[${OTRS_ASCII_COLOR_RED}m${DEFAULT_OTRS_DB_NAME}\e[0m" && OTRS_DB_NAME=${DEFAULT_OTRS_DB_NAME}
 [ -z "${OTRS_DB_USER}" ] && print_info "\e[${OTRS_ASCII_COLOR_BLUE}mOTRS_DB_USER\e[0m not set, setting value to \e[${OTRS_ASCII_COLOR_RED}m${DEFAULT_OTRS_DB_USER}\e[0m" && OTRS_DB_USER=${DEFAULT_OTRS_DB_USER}


### PR DESCRIPTION
There was a missing space at the `if` statement which breaks docker secrets support brought in by PR #60 