### PR TITLE
Wait for db only during the OTRS install process

### DIFF
--- a/otrs/run.sh
+++ b/otrs/run.sh
@@ -24,8 +24,6 @@ if [ "$OTRS_DEBUG" == "yes" ];then
   enable_debug_mode
 fi
 
-#Wait for database to come up
-wait_for_db
 print_otrs_ascii_logo
 #If OTRS_INSTALL isn't defined load a default install
 if [ "${OTRS_INSTALL}" != "yes" ]; then
@@ -62,6 +60,9 @@ if [ "${OTRS_INSTALL}" != "yes" ]; then
   su -c "${OTRS_ROOT}bin/otrs.Console.pl Maint::Cache::Delete" -s /bin/bash otrs
   set_skins
 else
+  #Wait for database to come up
+  wait_for_db
+  
   #If neither of previous cases is true the installer will be run.
   print_info "Starting \e[${OTRS_ASCII_COLOR_BLUE}m OTRS $OTRS_VERSION \e[0minstaller !!"
   check_host_mount_dir


### PR DESCRIPTION
## Why
I don't want to leave my MySQL root credentials in the ENVs for security reasons.

## Problem
For some reasons the "wait_db" checks the MySQL root credentials instead of regular OTRS user. So if I remove the root credentials from ENV the OTRS never starts.

## Solution
I decided to move the "wait_db" to the installation process only. Another possible approach is to create two "wait_db" functions; one for regular user and another one for root user.
