### PR TITLE
Fix deprecated docker MAINTAINER instruction 

### DIFF
--- a/mariadb/Dockerfile
+++ b/mariadb/Dockerfile
@@ -1,5 +1,5 @@
 FROM mariadb:10.1
-MAINTAINER "Juan Luis Baptiste" <juan.baptiste@gmail.com>
+LABEL maintainer="Juan Luis Baptiste <juan.baptiste@gmail.com>"
 ENV MYSQL_ROOT_PASSWORD changeme
 
 #mariadb image runs as mysql user (uid 27) but we need to do some configuration

--- a/otrs/Dockerfile
+++ b/otrs/Dockerfile
@@ -1,6 +1,6 @@
 #OTRS ticketing system docker image.
 FROM centos:7
-MAINTAINER Juan Luis Baptiste <juan.baptiste@gmail.com>
+LABEL maintainer="Juan Luis Baptiste <juan.baptiste@gmail.com>"
 ENV OTRS_VERSION=6.0.27-02
 ENV OTRS_ROOT "/opt/otrs/"
 ENV OTRS_BACKUP_DIR "/var/otrs/backups"


### PR DESCRIPTION
I replaced the instruction MAINTAINER by LABEL instruction, because MAINTAINER instruction is deprecated.