### PR TITLE
Dockerfile updated to install znuny 6.5.8 LTS

### DIFF
--- a/otrs/Dockerfile
+++ b/otrs/Dockerfile
@@ -1,7 +1,7 @@
 #OTRS ticketing system docker image.
 FROM centos:7
 LABEL maintainer="Juan Luis Baptiste <juan@juanbaptiste.tech>"
-ENV OTRS_VERSION=6.0.45-01
+ENV OTRS_VERSION=6.5.8-01
 ENV OTRS_ROOT "/opt/otrs/"
 ENV OTRS_BACKUP_DIR "/var/otrs/backups"
 ENV OTRS_CONFIG_DIR "${OTRS_ROOT}Kernel"
@@ -15,17 +15,18 @@ RUN yum install -y yum-plugin-fastestmirror && \
     yum install -y epel-release && \
     yum -y install https://harbottle.gitlab.io/epmel/7/x86_64/epmel-release.rpm && \
     yum update -y && \
-    yum -y install bzip2 cronie httpd mysql mod_perl \
+    yum -y install bzip2 cronie httpd mysql mod_perl perl-Apache-DBI \
     perl-core "perl(Crypt::SSLeay)" "perl(Net::LDAP)" "perl(URI)" \
-    procmail "perl(Date::Format)" "perl(LWP::UserAgent)" \
+    procmail "perl(Date::Format)" "perl(LWP::UserAgent)" "perl(Data::UUID)" \
     "perl(Net::DNS)" "perl(IO::Socket::SSL)" "perl(XML::Parser)" \
-    "perl(Apache2::Reload)" "perl(Crypt::Eksblowfish::Bcrypt)" \
+    "perl(Apache3::Reload)" "perl(Crypt::Eksblowfish::Bcrypt)" \
     "perl(Encode::HanExtra)" "perl(GD)" "perl(GD::Text)" "perl(GD::Graph)" \
     "perl(JSON::XS)" "perl(Mail::IMAPClient)" "perl(PDF::API2)" "perl(DateTime)" \
     "perl(Text::CSV_XS)" "perl(YAML::XS)" "perl(Text::CSV_XS)" "perl(DBD::mysql)" \
     perl-Moo "perl(namespace::clean)" "perl(Crypt::Random::Source)" "perl(Exporter::Tiny)" \
     "perl(Math::Random::ISAAC)" "perl(Math::Random::Secure)" "perl(Module::Find)" \
-    "perl(Types::TypeTiny)" rsyslog supervisor tar which && \
+    "perl(Types::TypeTiny)" rsyslog supervisor tar which cpanminus && \
+    cpanm iCal::Parser && \
     yum install -y https://download.znuny.org/releases/RPMS/rhel/7/znuny-${OTRS_VERSION}.noarch.rpm && \
     /opt/otrs/bin/otrs.CheckModules.pl && \
     yum clean all


### PR DESCRIPTION
The update was done due to critical and high vulnerabilities in znuny v6.0.45, mainly related to ckeditor plugin v4.17.1. This new znuny version uses ckeditor v4.22.1-min.

Note that this minor release needs some more dependencies with respect to 6.0.45 version:

* perl-Apache-DBI
* perl(Data::UUID)
* perl(Apache3::Reload)
* perl(iCal::Parser)